### PR TITLE
`.gitignore` の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__
+.ipynb_checkpoints
+/ignore


### PR DESCRIPTION
`.gitignore` の追加。
今後、公開したくないもの (AtCoder ID や個人情報などが入っているもの、個人的なメモなど) は `/ignore` に追加する。
(現在プライベートリポジトリなので全部公開されないが、パブリックになる可能性も見越して)