### PR TITLE
平均順位率の算出時、得点が0点のコンテストを見た時にエラーになるバグを修正

### DIFF
--- a/print_type.py
+++ b/print_type.py
@@ -34,9 +34,9 @@ def get_type(user_name):
             V = list(main_D[contest_name].values())
             K = list(main_D[contest_name].keys())
             ind = 0
-            while not (V[ind][0] <= rank <= V[ind][1]):
+            while ind < len(V) and (not (V[ind][0] <= rank <= V[ind][1])):
                 ind += 1
-            score = K[ind]
+            score = K[ind] if ind < len(K) else 0
             if score != 0 and V[ind][1] != V[ind][0]:
                 cnt += 1
                 per = (rank - V[ind][0]) / (V[ind][1] - V[ind][0])

--- a/print_type_hoseitoru.py
+++ b/print_type_hoseitoru.py
@@ -58,9 +58,9 @@ def get_type(user_name):
             V = list(main_D[contest_name].values())
             K = list(main_D[contest_name].keys())
             ind = 0
-            while not (V[ind][0] <= rank <= V[ind][1]):
+            while ind < len(V) and (not (V[ind][0] <= rank <= V[ind][1])):
                 ind += 1
-            score = K[ind]
+            score = K[ind] if ind < len(K) else 0
             if score != 0 and V[ind][1] != V[ind][0]:
                 n_contest += 1
                 per = (rank - V[ind][0]) / (V[ind][1] - V[ind][0])


### PR DESCRIPTION
補正値の再計算をしようとしたら見つかったので修正
(今まで一度もそういうユーザーを集計しなかったのだろうか？　特にUnrated参加なら、登録しっぱなしで忘れていた→0点、という人もいそうなものだけれど)