### PR TITLE
`requirements.txt` の更新

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.18.1
 flask
 gunicorn
+japanize_matplotlib


### PR DESCRIPTION
#22 をマージしてデプロイしたが、動かなくなった。
`heroku logs` で原因を見たところ、`japanize_matplotlib` ライブラリが見つからない、となっていた。
`requirement.txt` に書いていないことが原因であったので追記した。→マージ後、動くようになった

(参考)
`pip freeze > requirements.txt` (anaconda なら `conda list -e > conda_requirements.txt`)
で、環境中のライブラリをすべて自動出力してくれるらしい。
コードに大きな変更を加えたときはマージ前にやったほうがよさそう。