### PR TITLE
main に反映した ChatOps が動くか確認・develop ブランチにだけ反映した状態だとどうか確認

### DIFF
--- a/.github/workflows/chatops_date.yaml
+++ b/.github/workflows/chatops_date.yaml
@@ -10,4 +10,4 @@ jobs:
     if: ${{ github.event.issue.pull_request }} && startsWith(github.event.comment.body, '/date')
     runs-on: ubuntu-latest
     steps:
-      - run: echo "OK"
+      - run: echo "OK1"


### PR DESCRIPTION
- #33 で main に反映した ChatOps が動くか確認
  - 下記の最初のコメント (https://github.com/tomii9273/atcoder_type_checker/pull/35#issuecomment-1250127915) で動いた (https://github.com/tomii9273/atcoder_type_checker/actions/runs/3074503751) 。
  - 後から気づいたが、「/date」というコメントでないものでも動いているのは変だが、一旦このまま進める (コメントのたびに動いても実際そこまで問題ではない) 。
- 少なくとも main に反映すれば動くことは確認できた。その PR のベースブランチに反映した状態でもいけるか確認したい。
  - この PR で develop のみに変更を加え、develop から切ったブランチの新たな PR を作成して Actions を実行し、変更が反映されるか確認する。