### PR TITLE
CIで最終更新日を確認する際、日本時間の現在の日付を利用するようにする

### DIFF
--- a/.github/workflows/poc_ci.yaml
+++ b/.github/workflows/poc_ci.yaml
@@ -18,6 +18,6 @@ jobs:
           date_txt=$(echo $(cat update_dates/date_site.txt) | cut -c 1-10)
           echo $date_now
           echo $date_txt
-          if [[ $date_commit != $date_txt ]]; then exit 1; fi
+          if [[ $date_now != $date_txt ]]; then exit 1; fi
         env:
           TZ: 'Asia/Tokyo'


### PR DESCRIPTION
## WHY

CI で最終更新日を確認する際、合っていないのに通ったり (#33) 、合っているのに通らなかったりする。
これらは多分すべて日本時間 0 - 5 時くらいに発生しており、CI を実行するコンピュータのロケーションによって、現地時間が適用されてしまい、変わっている可能性がある。

## WHAT

- [x] 比較対象を「直前のコミットの日付 (日本時間かは不明)」でなく「日本時間の現在の日付」に変更する。
- [x] CIの挙動が変だった際にデバッグしやすいように、比較する日付は両方とも `echo` で出力するようにする。
- [x] 問題の時間の範囲で、少なくとも一度は CI が正常に動くことの確認: https://github.com/tomii9273/atcoder_type_checker/actions/runs/3114138752/ (日本時間3時)