### PR TITLE
ChatOps のブランチ名取得のテストコード (その1)

### DIFF
--- a/.github/workflows/chatops_date.yaml
+++ b/.github/workflows/chatops_date.yaml
@@ -16,6 +16,17 @@ jobs:
         run: |
           date_now=$(date +'%Y/%m/%d')
           date_txt=$(echo $(cat update_dates/date_site.txt) | cut -c 1-10)
+          echo '00' ${{ github.head_ref }}
+          echo '01' ${GITHUB_REF#refs/heads/}
+          echo '02' ${GITHUB_HEAD_REF}
+          echo '03' ${{ github.ref }}
+          echo '04' ${GITHUB_REF#refs/heads/}
+          echo '05' ${GITHUB_REF_CONTEXT#refs/heads/}
+          echo '1' $GITHUB_REF
+          echo '2' ${{ github.ref }}
+          echo '3' ${{ github.ref_name }}
+          echo '4' ${{ github.head_ref }}
+          echo '5' ${{ github.base_ref }}
           if [ $date_now != $date_txt ]; then
             git config user.name github-actions
             git config user.email github-actions@github.com


### PR DESCRIPTION
- 以下のサイトでの方法を試す (「PR にコメント時に実行」する GitHub Actions の例ではないが、一応試す)
  - https://dev.classmethod.jp/articles/how-to-get-a-ref-branch-within-a-workflow-execution-in-github-actions/
  - https://qiita.com/athagi/items/063a3adf2ae6f5b13b97
- 試すのは #40 で行う (→ 結局、取得できなかった)