### PR TITLE
ChatOps のブランチ名取得のテストコード (その2)

### DIFF
--- a/.github/workflows/chatops_date.yaml
+++ b/.github/workflows/chatops_date.yaml
@@ -12,6 +12,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Extract branch name
+        shell: bash
+        run: echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+        id: extract_branch
+
+      - name: Print branch name
+        env:
+          BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+        run: echo $BRANCH_NAME
+      
       - name: Update
         run: |
           date_now=$(date +'%Y/%m/%d')
@@ -27,6 +38,8 @@ jobs:
           echo '3' ${{ github.ref_name }}
           echo '4' ${{ github.head_ref }}
           echo '5' ${{ github.base_ref }}
+          echo "01" "::set-output name=branch::$(echo $PR | jq -r '.head.ref')"
+          echo "02" "::set-output name=branch::${GITHUB_REF#refs/heads/}"
           if [ $date_now != $date_txt ]; then
             git config user.name github-actions
             git config user.email github-actions@github.com


### PR DESCRIPTION
- #41 に加えて、以下のサイトでの方法も試す (「PR にコメント時に実行」する GitHub Actions の例ではないが、一応試す)
  - https://qiita.com/iery/items/43b72813c394050b8bbc 
  - https://buildersbox.corp-sansan.com/entry/2021/02/05/110000
- 試すのは #40 で行う (→ 結局、取得できなかった)