### PR TITLE
NumPy のバージョンの最新化

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.18.1
+numpy==1.24.0
 flask
 gunicorn
 japanize_matplotlib


### PR DESCRIPTION
## WHY
Heroku で #53 のプッシュ時に再びエラー。NumPy がうまく入っていないように見える。
https://dashboard.heroku.com/apps/atcoder-type-checker/activity/builds/784dfdd3-cb3d-4f1a-92c4-d6ad21ef98bf

現在指定の NumPy のバージョン (1.18.1) は古すぎて、Python 3.10 に対応していないらしい。
参考: https://teratail.com/questions/364033

## WHAT
最新バージョン (1.24.0) を指定
→ プッシュ・デプロイに成功した