### PR TITLE
ChatOps 修正

### DIFF
--- a/.github/workflows/chatops_date.yaml
+++ b/.github/workflows/chatops_date.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   update_date:
     name: "Update Date"
-    if: ${{ github.event.issue.pull_request }} && startsWith(github.event.comment.body, '/date')
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/date') }}
     runs-on: ubuntu-latest
     steps:
       - name: get upstream branch


### PR DESCRIPTION
## WHY
ChatOps が「/date」以外のコメントでも走ってしまう問題について、ChatGPTで別の記法を提案された。
https://chat.openai.com/c/b7f5495b-2d0b-4eb3-b487-34ca9b7cb7bc
現在の記法と同等であるとは言っているが、改善する可能性があるので、書き換えてみる。

## WHAT
- [x] 書き換え
- [x] 確認: #70 → 改善していた
  - 「/abcd」で走らない: https://github.com/tomii9273/atcoder_type_checker/actions/runs/5677053456
  - 「/date」で走る: https://github.com/tomii9273/atcoder_type_checker/actions/runs/5677070478

## ToDo

[warning 対応](https://github.com/tomii9273/atcoder_type_checker/actions/runs/5677070478)
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.