### PR TITLE
ChatOps の warning 修正

### DIFF
--- a/.github/workflows/chatops_date.yaml
+++ b/.github/workflows/chatops_date.yaml
@@ -15,7 +15,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::set-output name=branchname::$(curl -H "Authorization: token ${GITHUB_TOKEN}" ${{ github.event.issue.pull_request.url }} | jq '.head.ref' | sed 's/\"//g')"
+          echo "branchname=$(curl -H "Authorization: token ${GITHUB_TOKEN}" ${{ github.event.issue.pull_request.url }} | jq '.head.ref' | sed 's/\"//g')" >> $GITHUB_OUTPUT
 
       - name: Checkout upstream repo
         uses: actions/checkout@v3


### PR DESCRIPTION
#69, #70 で見つけた ChatOps の warning 
https://github.com/tomii9273/atcoder_type_checker/actions/runs/5677070478
を修正

以下の説明に従って `set-output` を更新
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/