### PR TITLE
グラフ表示の改善

### DIFF
--- a/app/src/plot_result.py
+++ b/app/src/plot_result.py
@@ -51,7 +51,7 @@ def plot_result(name: str, rate2: float, first_score: float, times: int, weighte
     ]
 
     rate_min = min(min(x), rate2) - 50
-    rate_max = max(4000, max(max(x), rate2) + 50)
+    rate_max = max(max(x), rate2) + 50
 
     rates = [rate_min] + [i for i in range(400, 2801, 400)] + [rate_max]
 


### PR DESCRIPTION
- 補正値の更新により横軸の右端が 4000 を下回るようになった。その場合横軸が見づらいので、横軸の右端は少なくとも 4000 以上になるように……しようと思ったが、目盛を 400 刻みにすれば見づらさは解消できると思い、そうした
  - 全員が各色のレート範囲を覚えているわけではないので、この方が親切
  - 後述のグリッドも入れやすい
- 特に縦軸を見やすくするために、グリッドを入れた
  - 色は、[AtCoder のレーティンググラフ](https://atcoder.jp/users/Tomii9273)のような白色だと見やすいが、真っ白だとチカチカしてしまったので (プロットの画質を良くしているせいもあるかも)、`#F0F0F0` にした

before
![スクリーンショット 2023-08-31 223302](https://github.com/tomii9273/atcoder_type_checker/assets/9714141/1c209a7a-e521-4df1-b51b-e51d5a756c64)

after
![スクリーンショット 2023-09-01 024735](https://github.com/tomii9273/atcoder_type_checker/assets/9714141/be954354-7cbb-4d73-aba1-fcdb05a7f05f)

## ToDo

グリッドが青点や黒線の奥に表示される設定にしているが、更新ボタンを押すと、手前に表示されることがある
マージ後もそれが頻発するなら、対策が必要

## 参考

- グリッドを奥に表示する方法など: https://qiita.com/sabopy/items/39a776bee12cec5b297c