### PR TITLE
yaml を prettier でフォーマット

### DIFF
--- a/.github/workflows/chatops_date.yaml
+++ b/.github/workflows/chatops_date.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.upstreambranch.outputs.branchname }}
-      
+
       - name: Update
         run: |
           date_now=$(date +'%Y/%m/%d')
@@ -40,4 +40,4 @@ jobs:
             git push
           fi
         env:
-          TZ: 'Asia/Tokyo'
+          TZ: "Asia/Tokyo"

--- a/.github/workflows/daily_update.yaml
+++ b/.github/workflows/daily_update.yaml
@@ -2,7 +2,7 @@ name: daily_update
 on:
   schedule:
     # 日本時間で毎日 15 時に実行
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 
 jobs:
   build:
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -45,4 +45,4 @@ jobs:
             git push origin main
           fi
         env:
-          TZ: 'Asia/Tokyo'
+          TZ: "Asia/Tokyo"

--- a/.github/workflows/monthly_hoseichi_update.yaml
+++ b/.github/workflows/monthly_hoseichi_update.yaml
@@ -2,7 +2,7 @@ name: monthly_hoseichi_update
 on:
   schedule:
     # 日本時間で毎月 1 日の 16 時に実行
-    - cron: '0 7 1 * *'
+    - cron: "0 7 1 * *"
 
 jobs:
   build:
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -43,4 +43,4 @@ jobs:
           git pull
           git push origin main
         env:
-          TZ: 'Asia/Tokyo'
+          TZ: "Asia/Tokyo"

--- a/.github/workflows/poc_ci.yaml
+++ b/.github/workflows/poc_ci.yaml
@@ -23,4 +23,4 @@ jobs:
           echo $date_txt
           if [[ $date_now != $date_txt ]]; then exit 1; fi
         env:
-          TZ: 'Asia/Tokyo'
+          TZ: "Asia/Tokyo"


### PR DESCRIPTION
## WHY・WHAT

prettier を導入してから、vscode で yaml を保存すると自動フォーマットされる。
「出力」タブでフォーマッターが動いていることを確認できる。
設定では html と css のみを指定しているはずなのに謎である。json はされない。
試しに `setting.json` の prettier 関連の設定をすべてコメントアウトし (ユーザー・ワークスペース (対象の設定無し)・フォルダのすべてで実施)、`"editor.defaultFormatter": null` を書く [1] のも試したが、それでも動く。
拡張機能を止めない限りされるのかもしれない。

ただ問題はなく、むしろありがたいので、GA の yaml を一度全部フォーマットする。

※ この自動フォーマット時には、なぜか一度「ソース管理」の更新ボタンを押さないと変更が反映されない (ファイル名が橙色に変化せず、M マークもつかない) 気がする…？

## 参考

[1] https://chat.openai.com/c/3ab16929-0b88-4c02-8042-d31671f8d316