### PR TITLE
vscode のバージョンアップに伴う設定ファイル更新

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "119"
     ],
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,


### PR DESCRIPTION
`source.organizeImports` の `true` と `"explicit"` は同じ意味で使われていたが、VSCode 1.85.0 以降、自動で `"explicit"` に書き換えられるようになったらしい。
参考: https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own